### PR TITLE
Add keep-alive checks to limit scope of http persistent connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.ipr
 *.iws
 target/
+.classpath
+.project
+.settings
 release.properties
 pom.xml.releaseBackup
 deploy.sh

--- a/common/src/main/java/com/ning/metrics/eventtracker/EventTrackerConfig.java
+++ b/common/src/main/java/com/ning/metrics/eventtracker/EventTrackerConfig.java
@@ -18,6 +18,7 @@ package com.ning.metrics.eventtracker;
 
 import org.skife.config.Config;
 import org.skife.config.Default;
+import org.skife.config.TimeSpan;
 
 public interface EventTrackerConfig
 {
@@ -185,4 +186,13 @@ public interface EventTrackerConfig
     @Config("eventtracker.scribe.max-idle-minutes")
     @Default("4")
     int getScribeMaxIdleTimeInMinutes();
+
+    /**
+     * How long can we keep on using the same HTTP persistent connection?
+     * Default is 2 minutes, to balance efficiency (longer) and load-balancing
+     * (shorter) constraints.
+     */
+    @Config("eventtracker.http.connection.maxKeepAlive")
+    @Default("120s")
+    TimeSpan getHttpMaxKeepAlive();
 }

--- a/http/src/main/java/com/ning/metrics/eventtracker/CollectorControllerHttpModule.java
+++ b/http/src/main/java/com/ning/metrics/eventtracker/CollectorControllerHttpModule.java
@@ -41,7 +41,8 @@ public class CollectorControllerHttpModule extends CollectorControllerModule
                     eventTrackerConfig.getCollectorHost(),
                     eventTrackerConfig.getCollectorPort(),
                     eventTrackerConfig.getEventType(),
-                    eventTrackerConfig.getHttpMaxWaitTimeInMillis()
+                    eventTrackerConfig.getHttpMaxWaitTimeInMillis(),
+                    eventTrackerConfig.getHttpMaxKeepAlive().getMillis()
                 );
                 bind(EventSender.class).toInstance(httpSender);
                 log.info("Enabled HTTP Event Logging");

--- a/http/src/main/java/com/ning/metrics/eventtracker/ExpirationTimer.java
+++ b/http/src/main/java/com/ning/metrics/eventtracker/ExpirationTimer.java
@@ -1,0 +1,42 @@
+package com.ning.metrics.eventtracker;
+
+/**
+ * Simple helper class that encapsulates details of how to keep track
+ * of relinquishing of time-bound things: and specifically that of
+ * closing of HTTP persistent connections.
+ */
+public class ExpirationTimer
+{
+    /**
+     * How long does it take for a resource to expire?
+     */
+    private final long maxKeepAliveMsecs;
+
+    /**
+     * When is resource going to expire next time; either
+     * undefined (0L), or timestamp of expiration.
+     */
+    private long expirationTime = 0L;
+    
+    public ExpirationTimer(long max) {
+        maxKeepAliveMsecs = max;
+    }
+
+    public final boolean isExpired() {
+        return isExpired(System.currentTimeMillis());
+    }
+    
+    public synchronized boolean isExpired(long now)
+    {
+        if (expirationTime == 0L) { // just starting, set start time, no expiry
+            expirationTime = now  + maxKeepAliveMsecs;
+            return false;
+        }
+        if (now >= maxKeepAliveMsecs) { // yup, expired
+            expirationTime = 0L;
+            return true;
+        }
+        // no, still valid
+        return false;
+    }
+}

--- a/http/src/test/java/com/ning/metrics/eventtracker/TestHttpSender.java
+++ b/http/src/test/java/com/ning/metrics/eventtracker/TestHttpSender.java
@@ -47,7 +47,10 @@ public class TestHttpSender
     private Server server;
     private Server errorServer;
     private HttpSender sender;
+
+    @SuppressWarnings("unused")
     private CallbackHandler failureCallbackHandler;
+    @SuppressWarnings("unused")
     private CallbackHandler successCallbackHandler;
 
     @BeforeClass(alwaysRun = true)
@@ -80,7 +83,8 @@ public class TestHttpSender
         System.setProperty("eventtracker.collector.port", Integer.toString(port));
         EventTrackerConfig config = new ConfigurationObjectFactory(System.getProperties()).build(EventTrackerConfig.class);
         // Set up sender
-        sender = new HttpSender(config.getCollectorHost(), config.getCollectorPort(), config.getEventType(), config.getHttpMaxWaitTimeInMillis());
+        sender = new HttpSender(config.getCollectorHost(), config.getCollectorPort(), config.getEventType(),
+                config.getHttpMaxWaitTimeInMillis(), config.getHttpMaxKeepAlive().getMillis());
         failureCallbackHandler = new CallbackHandler()
         {
             @Override

--- a/scribe/src/test/java/com/ning/metrics/eventtracker/TestIntegration.java
+++ b/scribe/src/test/java/com/ning/metrics/eventtracker/TestIntegration.java
@@ -35,7 +35,7 @@ public class TestIntegration
 {
     private final File tmpDir = new File(System.getProperty("java.io.tmpdir"), "collector");
 
-
+    @SuppressWarnings("unused")
     @BeforeTest(alwaysRun = true)
     private void setupTmpDir()
     {
@@ -48,6 +48,7 @@ public class TestIntegration
         }
     }
 
+    @SuppressWarnings("unused")
     @AfterTest(alwaysRun = true)
     private void cleanupTmpDir()
     {

--- a/smile/src/main/java/com/ning/metrics/eventtracker/HttpCollectorFactory.java
+++ b/smile/src/main/java/com/ning/metrics/eventtracker/HttpCollectorFactory.java
@@ -37,11 +37,13 @@ public class HttpCollectorFactory
     private final CollectorController controller;
     private static HttpSender eventSender;
 
+    // Factory method for tests cases
     public static synchronized CollectorController createHttpController(
         final String collectorHost,
         final int collectorPort,
         final EventType eventType,
         final long httpMaxWaitTimeInMillis,
+        final long httpMaxKeepAliveInMillis,
         final String spoolDirectoryName,
         final boolean isFlushEnabled,
         final int flushIntervalInSeconds,
@@ -57,6 +59,7 @@ public class HttpCollectorFactory
                 collectorPort,
                 eventType,
                 httpMaxWaitTimeInMillis,
+                httpMaxKeepAliveInMillis,
                 spoolDirectoryName,
                 isFlushEnabled,
                 flushIntervalInSeconds,
@@ -75,6 +78,7 @@ public class HttpCollectorFactory
         final int collectorPort,
         final EventType eventType,
         final long httpMaxWaitTimeInMillis,
+        final long httpMaxKeepAliveInMillis,
         final String spoolDirectoryName,
         final boolean isFlushEnabled,
         final int flushIntervalInSeconds,
@@ -84,7 +88,8 @@ public class HttpCollectorFactory
         final int maxUncommittedPeriodInSeconds
     )
     {
-        eventSender = new HttpSender(collectorHost, collectorPort, eventType, httpMaxWaitTimeInMillis);
+        eventSender = new HttpSender(collectorHost, collectorPort, eventType,
+                httpMaxWaitTimeInMillis, httpMaxKeepAliveInMillis);
 
         EventSerializer serializer = new ObjectOutputEventSerializer();
         switch (eventType) {

--- a/smile/src/test/java/com/ning/metrics/eventtracker/TestHttpSmileIntegration.java
+++ b/smile/src/test/java/com/ning/metrics/eventtracker/TestHttpSmileIntegration.java
@@ -45,6 +45,7 @@ public class TestHttpSmileIntegration
         }
     }
 
+    @SuppressWarnings("unused")
     @BeforeTest(alwaysRun = true)
     private void setupTmpDir()
     {
@@ -57,6 +58,7 @@ public class TestHttpSmileIntegration
         }
     }
 
+    @SuppressWarnings("unused")
     @AfterTest(alwaysRun = true)
     private void cleanupTmpDir()
     {
@@ -71,6 +73,7 @@ public class TestHttpSmileIntegration
             8080,
             EventType.SMILE,
             8000,
+            60000, // keep-alive
             tmpDir.getAbsolutePath(),
             true,
             10,


### PR DESCRIPTION
(since AHC does not seem to have this setting, alas!)
